### PR TITLE
ability to overload 'make' in a shell session

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This script is a dummy script, just to test the functionality of sh/exe-env.inc.sh:make.
+
+[[ -n "${SF_MAKE_SH_PASS:-}" ]] || {
+    echo >&2 "[ERR ] Expected SF_MAKE_SH_PASS=true but got SF_MAKE_SH_PASS=${SF_MAKE_SH_PASS:-}."
+    exit 1;
+}
+
+$(command -v make) $@

--- a/sh/exe-env.inc.sh
+++ b/sh/exe-env.inc.sh
@@ -43,3 +43,18 @@ if which brew >/dev/null 2>&1; then
 
     unset HOMEBREW_PREFIX
 fi
+
+if type make | grep -e "alias|function"; then
+    echo >&2 "[INFO] Refusing to overload 'make' with support-firecloud/sh/exe-env.inc.sh:make."
+    echo >&2 "[INFO] It is already overloaded by an alias/function: $(type make)."
+else
+    function make() {
+        [[ -x make.sh ]] || [[ -n "${SF_MAKE_SH_PASS:-}" ]] || {
+            $(command -v make) $@
+            return $?
+        }
+        echo >&2 "[INFO] Found a ${PWD}/make.sh. Executing that instead of $(command -v make)."
+        export SF_MAKE_SH_PASS=1
+        ./make.sh $@
+    }
+fi


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/rokmoln/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes: #179 
* Breaking change: [ ]

---

<!-- Describe your contribution -->
This allows for various useful scenarios, like:
* run all `make` commands on a development inside a sandbox (docker container) as described in #179 
* implement different make behaviour in a CI environment
* implement different make behaviour inside a sandbox (docker container)
* ?

I don't see any read negatives (and that's a problem! :) ), except for this corner-case of already having `make` as an alias/function.

cc @erpheus