### PR TITLE
support Brewfile.lock to lock homebrew in CI

### DIFF
--- a/Brewfile.lock
+++ b/Brewfile.lock
@@ -1,0 +1,4 @@
+https://github.com/Homebrew/brew 2.5.8 2020-10-01
+https://github.com/Homebrew/homebrew-core 973d88870aa3380a52a121234ff8902237d454ee 2020-10-01
+https://github.com/Homebrew/linuxbrew-core 70da6db7f060262556c134d785bbda7784886ee9 2020-10-01
+https://github.com/Homebrew/homebrew-cask cc47589aa1e5fcd5d63b3f5bc8e5493d6c89146a 2020-10-01

--- a/ci/brew-bootstrap.inc.sh
+++ b/ci/brew-bootstrap.inc.sh
@@ -97,7 +97,13 @@ source ${SUPPORT_FIRECLOUD_DIR}/sh/exe-env.inc.sh
 
 [[ "${CI}" != "true" ]] || {
     brew_config
-    [[ "${SF_SKIP_COMMON_BOOTSTRAP:-}" = "true" ]] || brew_update
+    [[ "${SF_SKIP_COMMON_BOOTSTRAP:-}" = "true" ]] || {
+        if [[ -f ${GIT_ROOT}/Brewfile.lock ]]; then
+            brew_lockfile
+        else
+            brew_update
+        fi
+    }
     source ${SUPPORT_FIRECLOUD_DIR}/ci/brew-install-ci.inc.sh
 }
 

--- a/ci/brew-util/update.inc.sh
+++ b/ci/brew-util/update.inc.sh
@@ -1,6 +1,86 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+function brew_lockfile() {
+    local BREWFILE_LOCK=${GIT_ROOT}/Brewfile.lock
+
+    [[ -f "${BREWFILE_LOCK}" ]] || {
+        echo_skip "Resetting Homebrew..."
+        return 1
+    }
+
+    echo_info "Found a ${BREWFILE_LOCK}:"
+    cat ${BREWFILE_LOCK}
+
+    local BREW_REMOTE=$(git -C "$(brew --prefix)/Homebrew" remote get-url origin)
+    echo_info "Homebrew remote: ${BREW_REMOTE}."
+
+    local BREW_FROM=$(git -C "$(brew --prefix)/Homebrew" rev-list -1 HEAD)
+    local BREW_TO=$(cat "${BREWFILE_LOCK}" | grep "^${BREW_REMOTE} " | cut -d" " -f2 || true)
+    [[ -z "${BREW_TO}" ]] || {
+        local BREW_SHALLOW_SINCE=$(cat "${BREWFILE_LOCK}" | grep "^${BREW_REMOTE} " | cut -d" " -f3-)
+
+        echo_do "Resetting Homebrew..."
+        echo_info "Resetting Homebrew from ${BREW_FROM} to ${BREW_TO}."
+        echo_info "Unshallow after ${BREW_SHALLOW_SINCE}."
+        git -C "$(brew --prefix)/Homebrew" fetch --tags
+        git -C "$(brew --prefix)/Homebrew" fetch --shallow-since "${BREW_SHALLOW_SINCE}"
+        git -C "$(brew --prefix)/Homebrew" reset --hard "${BREW_TO}"
+        echo_info "Reset Homebrew"
+        echo_info "from $(git -C "$(brew --prefix)/Homebrew" log -1 --format="%cd" "${BREW_FROM}") ${BREW_FROM}"
+        echo_info "to   $(git -C "$(brew --prefix)/Homebrew" log -1 --format="%cd" "${BREW_TO}") ${BREW_TO}"
+        echo_done
+    }
+
+    (
+        cd "$(brew --prefix)/Homebrew/Library/Taps"
+        cat ${BREWFILE_LOCK} | grep -v "^${BREW_REMOTE} " | while read -r BREW_TAP_LOCK; do
+            TAP_REMOTE=$(echo "${BREW_TAP_LOCK}" | cut -d" " -f1)
+            TAP_TO=$(echo "${BREW_TAP_LOCK}" | cut -d" " -f2)
+            TAP_SHALLOW_SINCE=$(echo "${BREW_TAP_LOCK}" | cut -d" " -f3-)
+
+            TAP=$(basename $(dirname "${TAP_REMOTE}"))/$(basename "${TAP_REMOTE}")
+            TAP=$(echo "${TAP}" | tr "A-Z" "a-z")
+
+            case ${OS_SHORT}-${TAP} in
+                darwin-homebrew/linuxbrew-core)
+                    echo_skip "Resetting Homebrew tap ${TAP}..."
+                    continue
+                    ;;
+                linux-homebrew/homebrew-core)
+                    echo_skip "Resetting Homebrew tap ${TAP}..."
+                    continue
+                    ;;
+                linux-homebrew/homebrew-cask)
+                    echo_skip "Resetting Homebrew tap ${TAP}..."
+                    continue
+                    ;;
+                linux-homebrew/linuxbrew-core)
+                    TAP=homebrew/homebrew-core
+                    ;;
+            esac
+
+            [[ -d ${TAP} ]] || {
+                echo_do "Installing Homebrew tap ${TAP}..."
+                brew tap "${TAP}"
+                echo_done
+            }
+
+            TAP_FROM=$(git -C "${TAP}" rev-list -1 HEAD)
+            echo_do "Resetting Homebrew tap ${TAP}..."
+            echo_info "Resetting Homebrew tap ${TAP} from ${TAP_FROM} to ${TAP_TO}."
+            echo_info "Unshallow after ${TAP_SHALLOW_SINCE}."
+            git -C "${TAP}" fetch --shallow-since "${TAP_SHALLOW_SINCE}"
+            git -C "${TAP}" reset --hard "${TAP_TO}"
+            echo_info "Reset Homebrew tap ${TAP}"
+            echo_info "from $(git -C "${TAP}" log -1 --format="%cd" "${TAP_FROM}") ${TAP_FROM}"
+            echo_info "to   $(git -C "${TAP}" log -1 --format="%cd" "${TAP_TO}") ${TAP_TO}"
+            echo_done
+        done
+    )
+    echo_done
+}
+
 function brew_update() {
     echo_do "brew: Updating..."
     # 'brew update' is currently flaky, resulting in 'transfer closed with outstanding read data remaining'

--- a/doc/ci-sh.md
+++ b/doc/ci-sh.md
@@ -94,7 +94,9 @@ currently described at https://docs.travis-ci.com/user/job-lifecycle/ .
   * see [repo/ci.sh/before-install.inc.sh](../repo/ci.sh/before-install.inc.sh)
   * maybe run the Docker container for Travis CI. See [integrate-travis-ci.md#docker](integrate-travis-ci.md#docker)
   * check out code (including git submodules)
-  * bootstrap the CI agent with system dependencies as instructed via `Brewfile.inc.sh`
+  * bootstrap the CI agent with system dependencies as instructed via `Brewfile.lock` and `Brewfile.inc.sh`
+    * `Brewfile.lock` has `<giturl> <commitish> <date of commit-ish to fetch>` lines
+    * `Brewfile.inc.sh` can call any commands, but `brew_install` is preferred, to install system dependencies
 * `install`
   * see [repo/ci.sh/install.inc.sh](../repo/ci.sh/install.inc.sh)
   * equivalent to running `make deps`

--- a/repo/mk/core.check.path.mk
+++ b/repo/mk/core.check.path.mk
@@ -21,6 +21,7 @@ SF_PATH_FILES_IGNORE += \
 SF_PATH_FILES_IGNORE += \
 	-e "^.github/" \
 	-e "^Brewfile.inc.sh$$" \
+	-e "^Brewfile.lock$$" \
 
 SF_PATH_FILES_IGNORE += \
 	-e "^AUTHORS$$" \


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/rokmoln/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->
Implement a `Brewfile.lock` mechanism to use specific `brew` versions/commits and specific commits of brew taps *in CI*. This will increase CI determinism.

Why not on local development machines - because in order to guarantee determinism, you need to uninstall all of `brew` and its installed formulas on every bootstrap, something that is neither time-friendly, nor sensible given that a multitude of projects.