### PR TITLE
add cirrus-ci pipeline

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,34 @@
+timeout_in: 30m
+
+env:
+  SF_CI_BREW_INSTALL: minimal
+  SF_LOG_BOOTSTRAP: "true"
+  SF_PRINTENV_BOOTSTRAP: "false"
+  TRANSCRYPT_PASSWORD: ""
+  V: ""
+
+task:
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH =~ 'cirrus*'
+  container:
+    # name: ubuntu:16.04
+    # NOTE using the prebuilt docker image of homebrew (linuxbrew)
+    # because homebrew cannot be installed as root,
+    # and creating a sudoer user and then running cirrus jobs through it failed
+    image: homebrew/ubuntu16.04
+  # see https://cirrus-ci.org/guide/tips-and-tricks/#custom-clone-command
+  clone_script: |
+    git clone --recursive --branch=$CIRRUS_BRANCH \
+      https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git \
+      $CIRRUS_WORKING_DIR
+    [ -z "$CIRRUS_PR" ] || git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+    git reset --hard $CIRRUS_CHANGE_IN_REPO
+  clone_submodule_script: |
+    git submodule sync --recursive
+    git submodule update --init --recursive
+  before_install_script: ./.ci.sh before_install
+  install_script: ./.ci.sh install
+  before_script_script: ./.ci.sh before_script
+  script_script: ./.ci.sh script
+  after_success_script: ./.ci.sh after_success
+  # after_failure_script: ./.ci.sh after_failure
+  # after_script_script: ./.ci.sh after_script

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,6 +8,7 @@ env:
   V: ""
 
 task:
+  name: "continuous-integration/cirrus" # otherwise 'main' shows in Github UI
   only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH =~ 'cirrus*'
   container:
     # name: ubuntu:16.04

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     * the bootstrapping is so generic that it is very easy to use `support-firecloud` in a multitude of CI solutions
       * `AppVeyor_________` [![AppVeyor Status][14]][13]
       * `CircleCI_________` [![CircleCI Status][4]][3]
+      * `Cirrus CI________` [![Cirrus CI Status][16]][15]
       * `Codeship_________` [![Codeship Status][8]][7]
       * `Github Actions CI` [![Github Actions CI Status][2]][1]
       * `Gitlab CI________` [![Gitlab CI Status][12]][11]
@@ -51,7 +52,7 @@ This initially supported [TobiiPro's Cloud Services development](https://github.
     * [SASS](https://github.com/rokmoln/sass-lint-config-firecloud)
 * set up a new `git` repository
   * [new `git` (and Github) repositories](doc/working-with-git-new.md)
-  * [how to license](doc/how-to-license.md)
+  * [how to license ](doc/how-to-license.md)
   * [integrate Travis CI](doc/integrate-travis-ci.md)
   * [.ci.sh](doc/ci-sh.md)
   * [how to manage secrets](doc/how-to-manage-secrets.md)
@@ -99,3 +100,5 @@ This initially supported [TobiiPro's Cloud Services development](https://github.
   [12]: https://gitlab.com/rokmoln/support-firecloud/badges/master/pipeline.svg
   [13]: https://ci.appveyor.com/project/andreineculau/support-firecloud/branch/master
   [14]: https://ci.appveyor.com/api/projects/status/da744jauw31fi66h/branch/master?svg=true
+  [15]: https://cirrus-ci.com/github/rokmoln/support-firecloud/master
+  [16]: https://api.cirrus-ci.com/github/rokmoln/support-firecloud.svg?branch=master

--- a/ci/env.cirrus-ci.inc.sh
+++ b/ci/env.cirrus-ci.inc.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+git config --global user.email "cirrus@cirrus-ci.com"
+git config --global user.name "Cirrus CI"
+
+CI_JOB_ID=${CIRRUS_BUILD_ID}
+CI_JOB_URL="https://cirrus-ci.com/build/${CIRRUS_BUILD_ID}"
+CI_PR_SLUG=
+if [[ -n "${CIRRUS_PR:-}" ]]; then
+    CI_PR_NUMBER=${CIRRUS_PR}
+    CI_PR_SLUG=https://github.com/${CIRRUS_REPO_FULL_NAME}/pull/${CIRRUS_PR}
+    unset CI_PR_NUMBER
+fi
+CI_REPO_SLUG=${CIRRUS_REPO_FULL_NAME}
+CI_IS_PR=false
+if [[ -n "${CIRRUS_PR:-}" ]]; then
+    CI_IS_PR=true
+fi
+CI_IS_CRON=false
+if [[ -n "${CIRRUS_CRON:-}" ]]; then
+    CI_IS_CRON=true
+fi
+CI_TAG=${CIRRUS_TAG:-}

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -90,5 +90,6 @@ function sf_ci_run() {
 [[ "${GITHUB_ACTIONS:-}" != "true" ]] || source ${SUPPORT_FIRECLOUD_DIR}/ci/env.github-actions.inc.sh
 [[ "${CI_NAME:-}" != "codeship" ]] || source ${SUPPORT_FIRECLOUD_DIR}/ci/env.codeship.inc.sh
 [[ "${GITLAB_CI:-}" != "true" ]] || source ${SUPPORT_FIRECLOUD_DIR}/ci/env.gitlab.inc.sh
+[[ "${CIRRUS_CI:-}" != "true" ]] || source ${SUPPORT_FIRECLOUD_DIR}/ci/env.cirrus-ci.inc.sh
 
 [[ -z "$*" ]] || sf_ci_run $@


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/rokmoln/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes: #205 
* Breaking change: [ ]

---

<!-- Describe your contribution -->
Except for the too-smooth integration (after adding their app to Github, I had no idea what now 🤷 ), Cirrus CI is quite a gem to work with. This comment is subjective, as I don't have consistent hands-on experience, but their docs were easy to follow https://cirrus-ci.org/guide/writing-tasks/ (except for `matrix`) and they seem to have the basics that everyone has **plus basics that others don't have** like `CIRRUS_LAST_GREEN_*`. And they show you CPU and memory consumption of the build. And a generous cross-platform support. And manual tasks. I'm surprised it is not more popular.